### PR TITLE
Change combinations() to pairwise() when constructing a list of edges in _BucketsToEdges

### DIFF
--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -19,7 +19,7 @@ import os
 import time
 import warnings
 from datetime import datetime
-from itertools import combinations
+from itertools import pairwise
 from typing import List, Tuple, Union
 
 import cudf
@@ -643,7 +643,7 @@ class _BucketsToEdges:
         # Create pairs of all documents within a bucket since they are near duplicates
         # Effectively create a edge list of all near duplicate documents
         for bucket_doc in bucket_docs:
-            edges.extend(combinations(bucket_doc, 2))
+            edges.extend(pairwise(bucket_doc))
         edges = pd.DataFrame(edges, columns=self.output_ids)
         edges = pa.Table.from_pandas(edges)
         result_df = cudf.DataFrame.from_arrow(edges)


### PR DESCRIPTION
combinations() creates all possible pairs between documents in a bucket. This is excessive, since having linear chain connecting documents with each other is enough for computing connected components in a subsequent stage.